### PR TITLE
Add test for locales in member transfer gems route

### DIFF
--- a/test/api/v3/integration/members/POST-transfer_gems.test.js
+++ b/test/api/v3/integration/members/POST-transfer_gems.test.js
@@ -4,6 +4,14 @@ import {
 } from '../../../../helpers/api-v3-integration.helper';
 import { v4 as generateUUID } from 'uuid';
 
+function findMessage (messages, receiverId) {
+  let message = _.find(messages, (inboxMessage) => {
+    return inboxMessage.uuid === receiverId;
+  });
+
+  return message;
+}
+
 describe('POST /members/transfer-gems', () => {
   let userToSendMessage;
   let receiver;
@@ -116,13 +124,8 @@ describe('POST /members/transfer-gems', () => {
     let updatedReceiver = await receiver.get('/user');
     let updatedSender = await userToSendMessage.get('/user');
 
-    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (inboxMessage) => {
-      return inboxMessage.uuid === userToSendMessage._id;
-    });
-
-    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (inboxMessage) => {
-      return inboxMessage.uuid === receiver._id;
-    });
+    let sendersMessageInReceiversInbox = findMessage(updatedReceiver.inbox.messages, userToSendMessage._id);
+    let sendersMessageInSendersInbox = findMessage(updatedSender.inbox.messages, receiver._id);
 
     let messageSentContent = t('privateMessageGiftIntro', {
       receiverName: receiver.profile.name,
@@ -150,13 +153,8 @@ describe('POST /members/transfer-gems', () => {
     let updatedReceiver = await receiver.get('/user');
     let updatedSender = await userToSendMessage.get('/user');
 
-    let sendersMessageInReceiversInbox = _.find(updatedReceiver.inbox.messages, (inboxMessage) => {
-      return inboxMessage.uuid === userToSendMessage._id;
-    });
-
-    let sendersMessageInSendersInbox = _.find(updatedSender.inbox.messages, (inboxMessage) => {
-      return inboxMessage.uuid === receiver._id;
-    });
+    let sendersMessageInReceiversInbox = findMessage(updatedReceiver.inbox.messages, userToSendMessage._id);
+    let sendersMessageInSendersInbox = findMessage(updatedSender.inbox.messages, receiver._id);
 
     let messageSentContent = t('privateMessageGiftIntro', {
       receiverName: receiver.profile.name,

--- a/test/helpers/translate.js
+++ b/test/helpers/translate.js
@@ -7,8 +7,8 @@ const STRING_DOES_NOT_EXIST_MSG = /^String '.*' not found.$/;
 // Use this to verify error messages returned by the server
 // That way, if the translated string changes, the test
 // will not break. NOTE: it checks against errors with string as well.
-export function translate (key, variables) {
-  let translatedString = i18n.t(key, variables);
+export function translate (key, variables, language) {
+  let translatedString = i18n.t(key, variables, language);
 
   expect(translatedString).to.not.be.empty;
   expect(translatedString).to.not.eql(STRING_ERROR_MSG);


### PR DESCRIPTION
This adds a test for your PR (https://github.com/HabitRPG/habitica/pull/8173) that illustrates a problem with it. The way you have it, the receiver's language is used for _both_ the sender and the receiver. 

The correct behavior will be for each locale to be respected for each user.